### PR TITLE
Refactor Post APIs

### DIFF
--- a/.idea/AppCodeProjects.Illithid.iml
+++ b/.idea/AppCodeProjects.Illithid.iml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id="Illithid" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="SPM" type="CIDR_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/Illithid.iml
+++ b/.idea/Illithid.iml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module classpath="AppCode" type="CIDR_MODULE" version="4" />
+<module classpath="AppCode" external.linked.project.id="Illithid" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="SPM" type="CIDR_MODULE" version="4" />

--- a/.idea/markdown.xml
+++ b/.idea/markdown.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownSettings">
+    <enabledExtensions>
+      <entry key="MermaidLanguageExtension" value="false" />
+      <entry key="PlantUMLLanguageExtension" value="false" />
+    </enabledExtensions>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,4 +3,17 @@
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>
+  <component name="SwiftPackageManagerSettings">
+    <option name="linkedExternalProjectsSettings">
+      <SwiftPackageManagerProjectSettings>
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+          </set>
+        </option>
+      </SwiftPackageManagerProjectSettings>
+    </option>
+  </component>
+  <component name="SwiftPackageManagerWorkspace" PROJECT_DIR="$PROJECT_DIR$" />
 </project>

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Alamofire/Alamofire.git",
         "state": {
           "branch": null,
-          "revision": "9e0328127dfb801cefe8ac53a13c0c90a7770448",
-          "version": "5.4.0"
+          "revision": "f82c23a8a7ef8dc1a49a8bfc6a96883e79121864",
+          "version": "5.5.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Thomvis/BrightFutures.git",
         "state": {
           "branch": null,
-          "revision": "9279defa6bdc21501ce740266e5a14d0119ddc63",
-          "version": "8.0.1"
+          "revision": "939858b811026f85e87847a808f0bea2f187e5c4",
+          "version": "8.1.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/tid-kijyun/Kanna.git",
         "state": {
           "branch": null,
-          "revision": "4a80ebe93b6966d5083394fcaaaff57a2fcec935",
-          "version": "5.2.3"
+          "revision": "f9e4922223dd0d3dfbf02ca70812cf5531fc0593",
+          "version": "5.2.7"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/kishikawakatsumi/KeychainAccess.git",
         "state": {
           "branch": null,
-          "revision": "654d52d30f3dd4592e944c3e0bccb53178c992f6",
-          "version": "4.2.1"
+          "revision": "84e546727d66f1adc5439debad16270d0fdd04e7",
+          "version": "4.2.2"
         }
       },
       {
@@ -60,8 +60,17 @@
         "repositoryURL": "https://github.com/OAuthSwift/OAuthSwift.git",
         "state": {
           "branch": null,
-          "revision": "fde77955e6983fbfaabd491709d52b8a82fda4d0",
-          "version": "2.1.2"
+          "revision": "8e62dc0243de97e37640e97fd0641fad4dbe6e1f",
+          "version": null
+        }
+      },
+      {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections.git",
+        "state": {
+          "branch": null,
+          "revision": "48254824bb4248676bf7ce56014ff57b142b77eb",
+          "version": "1.0.2"
         }
       },
       {

--- a/Sources/Illithid/Protocols/PostProvider.swift
+++ b/Sources/Illithid/Protocols/PostProvider.swift
@@ -20,6 +20,9 @@ public protocol PostProvider {
   var id: String { get }
   var isNsfw: Bool { get }
   var displayName: String { get }
+  /// The path of the endpoint where posts can be fetched
+  /// - Note: Relative to the Reddit API base URL
+  var postsPath: String { get }
 
   @discardableResult
   func posts(sortBy sort: PostSort, location: Location?,

--- a/Sources/Illithid/RedditAPI/Models/FrontPage.swift
+++ b/Sources/Illithid/RedditAPI/Models/FrontPage.swift
@@ -66,13 +66,4 @@ extension FrontPage: PostProvider {
       return "/"
     }
   }
-
-  public func posts(sortBy sort: PostSort, location: Location? = nil, topInterval: TopInterval? = nil,
-                    parameters: ListingParameters, queue: DispatchQueue = .main,
-                    completion: @escaping (Result<Listing, AFError>) -> Void)
-    -> DataRequest {
-    Illithid.shared.fetchPosts(for: self, sortBy: sort, location: location, topInterval: topInterval, params: parameters, queue: queue) { result in
-      completion(result)
-    }
-  }
 }

--- a/Sources/Illithid/RedditAPI/Models/FrontPage.swift
+++ b/Sources/Illithid/RedditAPI/Models/FrontPage.swift
@@ -39,12 +39,7 @@ public enum FrontPage: String, Codable, URLConvertible, Identifiable, CaseIterab
   }
 
   public func asURL() throws -> URL {
-    switch self {
-    case .all, .popular, .random:
-      return URL(string: "/r/\(self)/", relativeTo: Illithid.shared.baseURL)!
-    default:
-      return URL(string: "/", relativeTo: Illithid.shared.baseURL)!
-    }
+    URL(string: postsPath, relativeTo: Illithid.shared.baseURL)!
   }
 }
 
@@ -61,6 +56,15 @@ extension FrontPage: PostProvider {
 
   public var id: String {
     try! asURL().absoluteString
+  }
+
+  public var postsPath: String {
+    switch self {
+    case .all, .popular, .random:
+      return "/r/\(self)/"
+    default:
+      return "/"
+    }
   }
 
   public func posts(sortBy sort: PostSort, location: Location? = nil, topInterval: TopInterval? = nil,

--- a/Sources/Illithid/RedditAPI/Multireddits.swift
+++ b/Sources/Illithid/RedditAPI/Multireddits.swift
@@ -80,17 +80,6 @@ extension Multireddit: PostProvider {
   public var postsPath: String {
     "/user/\(owner)/m/\(name)"
   }
-
-  @discardableResult
-  public func posts(sortBy sort: PostSort, location: Location?, topInterval: TopInterval?,
-                    parameters: ListingParameters, queue _: DispatchQueue = .main,
-                    completion: @escaping (Result<Listing, AFError>) -> Void)
-    -> DataRequest {
-    Illithid.shared.fetchPosts(for: self, sortBy: sort, location: location,
-                               topInterval: topInterval, params: parameters) { result in
-      completion(result)
-    }
-  }
 }
 
 public extension Illithid {

--- a/Sources/Illithid/RedditAPI/Multireddits.swift
+++ b/Sources/Illithid/RedditAPI/Multireddits.swift
@@ -77,6 +77,10 @@ extension Multireddit: PostProvider {
     over18 ?? false
   }
 
+  public var postsPath: String {
+    "/user/\(owner)/m/\(name)"
+  }
+
   @discardableResult
   public func posts(sortBy sort: PostSort, location: Location?, topInterval: TopInterval?,
                     parameters: ListingParameters, queue _: DispatchQueue = .main,

--- a/Sources/Illithid/RedditAPI/Posts.swift
+++ b/Sources/Illithid/RedditAPI/Posts.swift
@@ -292,55 +292,6 @@ public extension Post {
       }
     }
   }
-
-  /// Fetches `Posts` from `r/all`, a metasubreddit which contains posts from all `Subreddits`
-  /// - Parameters:
-  ///   - postSort: The `PostSort` by which to sort the `Posts`
-  ///   - location:
-  ///   - topInterval: The interval in which to search for top `Posts` when `postSort` is `.top`
-  ///   - params: Default parameters applicable to every `Listing` returning endpoint on Reddit
-  ///   - queue: The `DispatchQueue` on which the completion handler will be called
-  ///   - completion: The callback function to execute when we get the `Post` `Listing` back from Reddit
-  @discardableResult
-  static func all(sortBy postSort: PostSort, location: Location? = nil, topInterval: TopInterval? = nil,
-                  params: ListingParameters = .init(), queue: DispatchQueue = .main, completion: @escaping (Result<Listing, AFError>) -> Void)
-    -> DataRequest {
-    Illithid.shared.fetchPosts(for: FrontPage.all, sortBy: postSort, location: location, topInterval: topInterval,
-                               params: params, queue: queue, completion: completion)
-  }
-
-  /// Fetches `Posts` from `r/popular`, which is a subset of the posts from `r/all` and is the default front page for non-authenticated users
-  /// The announcement of `r/popular` and further details may be found [here](https://www.reddit.com/r/announcements/comments/5u9pl5)
-  /// - Parameters:
-  ///   - postSort: The `PostSort` by which to sort the `Posts`
-  ///   - location:
-  ///   - topInterval: The interval in which to search for top `Posts` when `postSort` is `.top`
-  ///   - params: Default parameters applicable to every `Listing` returning endpoint on Reddit
-  ///   - queue: The `DispatchQueue` on which the completion handler will be called
-  ///   - completion: The callback function to execute when we get the `Post` `Listing` back from Reddit
-  @discardableResult
-  static func popular(sortBy postSort: PostSort, location: Location? = nil, topInterval: TopInterval? = nil,
-                      params: ListingParameters = .init(), queue: DispatchQueue = .main, completion: @escaping (Result<Listing, AFError>) -> Void)
-    -> DataRequest {
-    Illithid.shared.fetchPosts(for: FrontPage.popular, sortBy: postSort, location: location, topInterval: topInterval,
-                               params: params, queue: queue, completion: completion)
-  }
-
-  /// Fetches `Posts` from a random `Subreddit`
-  /// - Parameters:
-  ///   - postSort: The `PostSort` by which to sort the `Posts`
-  ///   - location:
-  ///   - topInterval: The interval in which to search for top `Posts` when `postSort` is `.top`
-  ///   - params: Default parameters applicable to every `Listing` returning endpoint on Reddit
-  ///   - queue: The `DispatchQueue` on which the completion handler will be called
-  ///   - completion: The callback function to execute when we get the `Post` `Listing` back from Reddit
-  @discardableResult
-  static func random(sortBy postSort: PostSort, location: Location? = nil, topInterval: TopInterval? = nil,
-                     params: ListingParameters = .init(), queue: DispatchQueue = .main, completion: @escaping (Result<Listing, AFError>) -> Void)
-    -> DataRequest {
-    Illithid.shared.fetchPosts(for: FrontPage.random, sortBy: postSort, location: location, topInterval: topInterval,
-                               params: params, queue: queue, completion: completion)
-  }
 }
 
 public extension Post {

--- a/Sources/Illithid/RedditAPI/Posts.swift
+++ b/Sources/Illithid/RedditAPI/Posts.swift
@@ -243,6 +243,18 @@ public extension Illithid {
   }
 }
 
+public extension PostProvider {
+  func posts(sortBy sort: PostSort, location: Location?, topInterval: TopInterval?,
+             parameters: ListingParameters, queue: DispatchQueue = .main,
+             completion: @escaping (Result<Listing, AFError>) -> Void)
+    -> DataRequest {
+    Illithid.shared.fetchPosts(for: self, sortBy: sort, location: location,
+                               topInterval: topInterval, params: parameters, queue: queue) { result in
+      completion(result)
+    }
+  }
+}
+
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public extension Post {
   static func fetch(name: Fullname, queue: DispatchQueue = .main) -> AnyPublisher<Post, AFError> {

--- a/Sources/Illithid/RedditAPI/Subreddits.swift
+++ b/Sources/Illithid/RedditAPI/Subreddits.swift
@@ -81,6 +81,10 @@ extension Subreddit: PostProvider {
     over18 ?? false
   }
 
+  public var postsPath: String {
+    "/r/\(displayName)"
+  }
+
   public func posts(sortBy sort: PostSort, location: Location?, topInterval: TopInterval?,
                     parameters: ListingParameters, queue: DispatchQueue = .main,
                     completion: @escaping (Result<Listing, AFError>) -> Void)

--- a/Sources/Illithid/RedditAPI/Subreddits.swift
+++ b/Sources/Illithid/RedditAPI/Subreddits.swift
@@ -51,8 +51,9 @@ public extension Illithid {
    Loads subreddits from the Reddit API
 
    - Parameters:
-     - subredditSort: Subreddit sort method
+     - sort: Subreddit sort method
      - params: Standard listing parameters object
+     - queue: The dispatch queue the completion handler will be called on
      - completion: Completion handler, is passed the listable as an argument
    */
   func subreddits(sortBy sort: SubredditSort = .popular,
@@ -83,16 +84,6 @@ extension Subreddit: PostProvider {
 
   public var postsPath: String {
     "/r/\(displayName)"
-  }
-
-  public func posts(sortBy sort: PostSort, location: Location?, topInterval: TopInterval?,
-                    parameters: ListingParameters, queue: DispatchQueue = .main,
-                    completion: @escaping (Result<Listing, AFError>) -> Void)
-    -> DataRequest {
-    Illithid.shared.fetchPosts(for: self, sortBy: sort, location: location,
-                               topInterval: topInterval, params: parameters, queue: queue) { result in
-      completion(result)
-    }
   }
 }
 

--- a/Sources/Ulithari/Gfycat/RedGif.swift
+++ b/Sources/Ulithari/Gfycat/RedGif.swift
@@ -48,7 +48,7 @@ public extension RedGif {
     // MARK: Lifecycle
 
     public init(id: String, createDate: Date, hasAudio: Bool, width: Int, height: Int, likes: Int, tags: [String],
-                verified: Bool, views: Int, duration: Int, published: Bool, urls: Urls, userName: String,
+                verified: Bool, views: Int, duration: Double, published: Bool, urls: Urls, userName: String,
                 type: Int, avgColor: String, gallery: String?) {
       self.id = id
       self.createDate = createDate
@@ -111,7 +111,7 @@ public extension RedGif {
     public let tags: [String]
     public let verified: Bool
     public let views: Int
-    public let duration: Int
+    public let duration: Double
     public let published: Bool
     public let urls: Urls
     public let userName: String


### PR DESCRIPTION
Simplifies the `Post` fetch APIs by refactoring the `PostProvider` protocol to provide a more useful abstraction over the particulars of fetching posts from the different types of reddit feeds